### PR TITLE
#17 Align MS web site style to the one used for GeoNode (recommended fix)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -157,6 +157,7 @@ a {
     margin-top: 2rem;
     margin-right: 0;
     margin-left: 0;
+    justify-content: center;
 }
 
 .version-columns > [class*="col-"] {
@@ -188,7 +189,6 @@ a {
 }
 
 .version-card:hover .version-text {
-    color: #f2a900;
     text-decoration: underline;
 }
 


### PR DESCRIPTION
Fix hover color and card alignment according to [this comment](https://github.com/geosolutions-it/mapstore.io/pull/18#issuecomment-5331012445)